### PR TITLE
feat!(ccm544-547,866): 2つあるSEQ SysEx.の表記を統一

### DIFF
--- a/electone.xml
+++ b/electone.xml
@@ -5910,11 +5910,13 @@
               <Data>@SYSEX F0H 43H 70H 78H 41H 96 #VL F7H</Data>
             </CCM>
           </Folder>
-          <CCM ID="544" Name="Sequence [SEQ.1] - [SEQ.4]">
-            <Value Min="0" Max="1" TableID="2"/>
-            <Gate Min="0" Max="3" Offset="97" TableID="4"/>
-            <Data>@SYSEX F0H 43H 70H 78H 41H #GL #VL F7H</Data>
-          </CCM>
+          <Folder Name="Sequence">
+            <CCM ID="544" Name="Sequence [SEQ.1] - [SEQ.4]">
+              <Value Min="0" Max="1" TableID="2"/>
+              <Gate Min="0" Max="3" Offset="97" TableID="4"/>
+              <Data>@SYSEX F0H 43H 70H 78H 41H #GL #VL F7H</Data>
+            </CCM>
+          </Folder>
           <Table ID="300">
             <Entry Label="Volume24" Value="0"/>
             <Entry Label="Volume23" Value="1"/>

--- a/electone.xml
+++ b/electone.xml
@@ -5910,24 +5910,11 @@
               <Data>@SYSEX F0H 43H 70H 78H 41H 96 #VL F7H</Data>
             </CCM>
           </Folder>
-          <Folder Name="Sequence">
-            <CCM ID="544" Name="Sequence 1 [SEQ.1]">
-              <Value Min="0" Max="1" TableID="2"/>
-              <Data>@SYSEX F0H 43H 70H 78H 41H 97 #VL F7H</Data>
-            </CCM>
-            <CCM ID="545" Name="Sequence 2 [SEQ.2]">
-              <Value Min="0" Max="1" TableID="2"/>
-              <Data>@SYSEX F0H 43H 70H 78H 41H 98 #VL F7H</Data>
-            </CCM>
-            <CCM ID="546" Name="Sequence 3 [SEQ.3]">
-              <Value Min="0" Max="1" TableID="2"/>
-              <Data>@SYSEX F0H 43H 70H 78H 41H 99 #VL F7H</Data>
-            </CCM>
-            <CCM ID="547" Name="Sequence 4 [SEQ.4]">
-              <Value Min="0" Max="1" TableID="2"/>
-              <Data>@SYSEX F0H 43H 70H 78H 41H 100 #VL F7H</Data>
-            </CCM>
-          </Folder>
+          <CCM ID="544" Name="Sequence [SEQ.1] - [SEQ.4]">
+            <Value Min="0" Max="1" TableID="2"/>
+            <Gate Min="0" Max="3" Offset="97" TableID="4"/>
+            <Data>@SYSEX F0H 43H 70H 78H 41H #GL #VL F7H</Data>
+          </CCM>
           <Table ID="300">
             <Entry Label="Volume24" Value="0"/>
             <Entry Label="Volume23" Value="1"/>
@@ -6688,12 +6675,7 @@
             <Folder Name="Rhythm Sequence Parameters">
               <CCM ID="866" Name="Sequence [SEQ.1] - [SEQ.4]">
                 <Value Min="0" Max="1" TableID="2"/>
-                <Gate Min="0" Max="3">
-                  <Entry Label="SEQ.1" Value="0"/>
-                  <Entry Label="SEQ.2" Value="1"/>
-                  <Entry Label="SEQ.3" Value="2"/>
-                  <Entry Label="SEQ.4" Value="3"/>
-                </Gate>
+                <Gate Min="0" Max="3" TableID="4"/>
                 <Data>@SYSEX F0H 43H 70H 78H 44H 13H 01H #GL #VL F7H</Data>
               </CCM>
             </Folder>
@@ -38674,6 +38656,12 @@
         <Entry Label="715.0ms" Value="7150"/>
       </Table>
     </Folder>
+    <Table ID="4">
+      <Entry Label="SEQ.1" Value="0"/>
+      <Entry Label="SEQ.2" Value="1"/>
+      <Entry Label="SEQ.3" Value="2"/>
+      <Entry Label="SEQ.4" Value="3"/>
+    </Table>
     <Table ID="0">
       <Entry Label="Off" Value="0"/>
       <Entry Label="On" Value="1"/>

--- a/tools/ccm.ts
+++ b/tools/ccm.ts
@@ -42,6 +42,13 @@ const chTable = new Domino.Table({ id: 3 }, [
   new Domino.Entry({ value: 16, label: "CH16" }),
 ]);
 
+const seqTable = new Domino.Table({ id: 4 }, [
+  new Domino.Entry({ value: 0, label: "SEQ.1" }),
+  new Domino.Entry({ value: 1, label: "SEQ.2" }),
+  new Domino.Entry({ value: 2, label: "SEQ.3" }),
+  new Domino.Entry({ value: 3, label: "SEQ.4" }),
+]);
+
 const chGate = new Domino.Gate({
   min: 0x01,
   max: 0x10,
@@ -50,6 +57,7 @@ const chGate = new Domino.Gate({
 });
 
 export const ccmList = new Domino.ControlChangeMacroList([
+  seqTable,
   new Domino.CCMFolder({ name: "Channel Message" }, [
     swTable1,
     swTable2,
@@ -367,12 +375,21 @@ export const ccmList = new Domino.ControlChangeMacroList([
         new Domino.CCMFolder({ name: "Rotary Speaker" }, [
           createExPanelSwCCM(543, 0x60, "Rotary Speaker Speed"),
         ]),
-
         new Domino.CCMFolder({ name: "Sequence" }, [
-          createExPanelSwCCM(544, 0x61, "Sequence 1 [SEQ.1]"),
-          createExPanelSwCCM(545, 0x62, "Sequence 2 [SEQ.2]"),
-          createExPanelSwCCM(546, 0x63, "Sequence 3 [SEQ.3]"),
-          createExPanelSwCCM(547, 0x64, "Sequence 4 [SEQ.4]"),
+          new Domino.CCM({ id: 544, name: "Sequence [SEQ.1] - [SEQ.4]" }, {
+            value: new Domino.Value({
+              min: 0,
+              max: 1,
+              tableId: swTable1.param.id,
+            }),
+            gate: new Domino.Gate({
+              min: 0,
+              max: 3,
+              tableId: seqTable.param.id,
+              offset: 0x61,
+            }),
+            data: new Domino.Data(`@SYSEX F0H 43H 70H 78H 41H #GL #VL F7H`),
+          }),
         ]),
       ]),
       new Domino.CCMFolder({ name: "Midi Parameter" }, [
@@ -778,12 +795,11 @@ export const ccmList = new Domino.ControlChangeMacroList([
                 max: 1,
                 tableId: swTable1.param.id,
               }),
-              gate: new Domino.Gate({ min: 0, max: 3 }, [
-                new Domino.Entry({ value: 0, label: "SEQ.1" }),
-                new Domino.Entry({ value: 1, label: "SEQ.2" }),
-                new Domino.Entry({ value: 2, label: "SEQ.3" }),
-                new Domino.Entry({ value: 3, label: "SEQ.4" }),
-              ]),
+              gate: new Domino.Gate({
+                min: 0,
+                max: 3,
+                tableId: seqTable.param.id,
+              }),
               data: new Domino.Data(
                 `@SYSEX F0H 43H 70H 78H 44H 13H 01H #GL #VL F7H`,
               ),


### PR DESCRIPTION
Fix #38 

|544-547 -> 544に統一|866|
|-|-|
| ![image](https://user-images.githubusercontent.com/47011206/164988001-228cd89b-46fb-4d8c-8d95-7449eae8c78b.png) | ![image](https://user-images.githubusercontent.com/47011206/164988013-e2b80490-367f-4765-b3a4-23627b81f9da.png) |

両方で同じ見た目になるように統一